### PR TITLE
fix login

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/github/szpontium/api/prometheus/PrometheusLoginHelper.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/szpontium/api/prometheus/PrometheusLoginHelper.kt
@@ -95,7 +95,7 @@ class PrometheusLoginHelper {
 
         // 3. Właściwe logowanie — bez redirectów, żeby odczytać nagłówek Location
         val formBody = buildString {
-            append("Alias=").append(UrlEncoderUtil.encode(login))
+            append("UserName=").append(UrlEncoderUtil.encode(login))
             append("&Password=").append(UrlEncoderUtil.encode(password))
             append("&captcha-response=").append(UrlEncoderUtil.encode(captchaResponse))
             append("&__RequestVerificationToken=").append(UrlEncoderUtil.encode(csrfToken))
@@ -137,7 +137,7 @@ class PrometheusLoginHelper {
         return try {
             val body = httpClient.post("https://eduvulcan.pl/Account/QueryUserInfo") {
                 contentType(ContentType.Application.FormUrlEncoded)
-                setBody("alias=${UrlEncoderUtil.encode(username)}")
+                setBody("UserName=${UrlEncoderUtil.encode(username)}")
             }.bodyAsText()
             json.parseToJsonElement(body)
                 .jsonObject["data"]?.jsonObject


### PR DESCRIPTION
* Update API calls to use UserName instead of Alias parameter

Key features implemented:
- Modified PrometheusLoginHelper.kt to replace "Alias" with "UserName" in all API POST requests
- Updated login form submission to use "UserName=" parameter instead of "Alias="
- Changed QueryUserInfo endpoint to send "UserName=" instead of "alias=" parameter
- Maintained all existing functionality while adapting to new API requirements

The changes ensure compatibility with EduVulcan's updated API authentication requirements by using the correct parameter names for user identification.

* Update .gitignore to exclude additional files

Added various file patterns to .gitignore to exclude build artifacts and IDE files.

---------

Przyszponcone uzywajac qwena